### PR TITLE
_add_dense, _mul_vector, _mul_multivector with tests

### DIFF
--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from scipy.sparse import coo_array
+from scipy.sparse import coo_array, issparse
 
 
 def test_shape_constructor():
@@ -213,3 +213,26 @@ def test_eliminate_zeros():
     assert arr1d.count_nonzero() == 1
     assert np.array_equal(arr1d.toarray(), np.array([0, 1]))
     assert np.array_equal(arr1d.row, np.array([1]))
+
+
+def test_1d_add_dense():
+    res = coo_array([0, -2, -3, 0]) + np.array([0, 1, 2, 3])
+    assert np.array_equal(res, [0, -1, -1, 3])
+    assert not issparse(res)
+
+
+def test_1d_mul_vector():
+    res = coo_array([0, -2, -3, 0])._mul_vector(np.array([0, 1, 2, 3]))
+    assert np.array_equal(res, [-8])
+
+
+def test_check_2d_mul_multivector():
+    A = coo_array([[0, 1, 2, 3], [3, 2, 1, 0]])
+    result = A @ A.T
+    assert np.array_equal(result.toarray(), [[14, 4],[4 , 14]])
+
+
+def test_1d_mul_multivector():
+    other = np.array([[0, 1, 2, 3], [3, 2, 1, 0]]).T
+    res = coo_array([0, -2, -3, 0])._mul_multivector(other)
+    assert np.array_equal(res, [-8, -7])


### PR DESCRIPTION
Here are some additional changes to provide _add_dense, _mul_vector and _mul_multivector.
Tests are included as well. 

Some thoughts:
- I'm guessing we will have to rethink _mul_dispatch to get _mul_multivector and friends to work with ndim>2. But this at least gets the 1-d working.
- I construct a vector of zeros to send into `coo_matvec`, and there might be a better way to handle that by changing coo_matvec but I thought that should not be done here.  Maybe in a different PR.

- It seems to me that `csr_array` could also be made 1d by ensuring that `indptr` is just `[self.nzz]`.  I don't know if there would be any advantages to that. 