### PR TITLE
Switch to leftpadding self.shape in coo-1d arrays when using 2d tools

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -73,6 +73,11 @@ class _spbase:
         return len(self._shape)
 
     @property
+    def _shape_as_2d(self):
+        s = self._shape
+        return (1, s[-1]) if len(s) == 1 else s
+
+    @property
     def _bsr_container(self):
         from ._bsr import bsr_array
         return bsr_array

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -74,22 +74,22 @@ class _coo_base(_data_matrix, _minmax_mixin):
                     self.has_canonical_format = False
             else:
                 # dense argument
-                A = np.asarray(arg1)
+                M = np.asarray(arg1)
                 if not is_array:
-                    A = np.atleast_2d(A)
-                    if A.ndim != 2:
+                    M = np.atleast_2d(M)
+                    if M.ndim != 2:
                         raise TypeError('expected dimension <= 2 array or matrix')
 
-                self._shape = check_shape(A.shape, allow_ndim=is_array)
+                self._shape = check_shape(M.shape, allow_ndim=is_array)
                 if shape is not None:
                     if check_shape(shape, allow_ndim=is_array) != self._shape:
                         raise ValueError('inconsistent shapes: %s != %s' %
                                          (shape, self._shape))
                 index_dtype = self._get_index_dtype(maxval=max(self._shape))
-                indices = A.nonzero()
+                indices = M.nonzero()
                 self.indices = tuple(idx.astype(index_dtype, copy=False)
                                      for idx in indices)
-                self.data = A[indices]
+                self.data = M[indices]
                 self.has_canonical_format = True
 
         if dtype is not None:
@@ -303,7 +303,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             M,N = self.shape
             idx_dtype = self._get_index_dtype(
-                (self.col, self.row), maxval=max(self.nnz, *self.shape)
+                (self.col, self.row), maxval=max(self.nnz, M)
             )
             row = self.row.astype(idx_dtype, copy=False)
             col = self.col.astype(idx_dtype, copy=False)
@@ -347,7 +347,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         else:
             M,N = self.shape
             idx_dtype = self._get_index_dtype(
-                (self.row, self.col), maxval=max(self.nnz, *self.shape)
+                (self.row, self.col), maxval=max(self.nnz, N)
             )
             row = self.row.astype(idx_dtype, copy=False)
             col = self.col.astype(idx_dtype, copy=False)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -99,17 +99,15 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
     @property
     def row(self):
-        if self.ndim > 1:
-            return self.indices[0]
-        return np.zeros(self.nnz, dtype=self.indices[0].dtype)
+        return self.indices[-2] if self.ndim > 1 else np.zeros_like(self.col)
 
 
     @row.setter
     def row(self, new_row):
         if self.ndim < 2:
             raise ValueError('cannot set row attribute of a 1-dimensional sparse array')
-        new_row = np.asarray(new_row, dtype=self.indices[0].dtype)
-        self.indices = (new_row,) + self.indices[1:]
+        new_row = np.asarray(new_row, dtype=self.indices[-2].dtype)
+        self.indices = self.indices[:-2] + (new_row,) + self.indices[-1:]
 
     @property
     def col(self):

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -74,22 +74,22 @@ class _coo_base(_data_matrix, _minmax_mixin):
                     self.has_canonical_format = False
             else:
                 # dense argument
-                M = np.asarray(arg1)
+                A = np.asarray(arg1)
                 if not is_array:
-                    M = np.atleast_2d(M)
-                    if M.ndim != 2:
+                    A = np.atleast_2d(A)
+                    if A.ndim != 2:
                         raise TypeError('expected dimension <= 2 array or matrix')
 
-                self._shape = check_shape(M.shape, allow_ndim=is_array)
+                self._shape = check_shape(A.shape, allow_ndim=is_array)
                 if shape is not None:
                     if check_shape(shape, allow_ndim=is_array) != self._shape:
                         raise ValueError('inconsistent shapes: %s != %s' %
                                          (shape, self._shape))
                 index_dtype = self._get_index_dtype(maxval=max(self._shape))
-                indices = M.nonzero()
+                indices = A.nonzero()
                 self.indices = tuple(idx.astype(index_dtype, copy=False)
                                      for idx in indices)
-                self.data = M[indices]
+                self.data = A[indices]
                 self.has_canonical_format = True
 
         if dtype is not None:

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -268,7 +268,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
             raise ValueError("Cannot densify higher-rank sparse array")
         # This handles both 0D and 1D cases correctly regardless of the
         # original shape.
-        *_, M, N = (1, 1) + self.shape
+        M, N = self._shape_as_2d
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
                     B.ravel('A'), fortran)
         # Note: reshape() doesn't copy here, but does return a new array (view).
@@ -527,8 +527,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         dtype = upcast_char(self.dtype.char, other.dtype.char)
         result = np.array(other, dtype=dtype, copy=True)
         fortran = int(result.flags.f_contiguous)
-        M = self.shape[0] if self.ndim > 1 else 1
-        N = self.shape[-1]
+        M, N = self._shape_as_2d
         coo_todense(M, N, self.nnz, self.row, self.col, self.data,
                     result.ravel('A'), fortran)
         return self._container(result, copy=False)

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -160,17 +160,17 @@ def test_transpose_with_axis():
 
 def test_1d_row_and_col():
     res = coo_array([1, -2, -3])
-    assert np.array_equal(res.row, np.array([0, 1, 2]))
-    assert np.array_equal(res.col, np.zeros_like(res.row))
+    assert np.array_equal(res.col, np.array([0, 1, 2]))
+    assert np.array_equal(res.row, np.zeros_like(res.row))
     assert res.row.dtype == res.col.dtype
 
-    res.row = [1, 2, 3]
+    res.col = [1, 2, 3]
     assert len(res.indices) == 1
-    assert np.array_equal(res.row, np.array([1, 2, 3]))
+    assert np.array_equal(res.col, np.array([1, 2, 3]))
     assert res.row.dtype == res.col.dtype
 
-    with pytest.raises(ValueError, match="cannot set col attribute"):
-        res.col = [1, 2, 3]
+    with pytest.raises(ValueError, match="cannot set row attribute"):
+        res.row = [1, 2, 3]
 
 
 def test_1d_tocsc_tocsr_todia_todok():
@@ -229,7 +229,8 @@ def test_eliminate_zeros():
     assert arr1d.nnz == 1
     assert arr1d.count_nonzero() == 1
     assert np.array_equal(arr1d.toarray(), np.array([0, 1]))
-    assert np.array_equal(arr1d.row, np.array([1]))
+    assert np.array_equal(arr1d.col, np.array([1]))
+    assert np.array_equal(arr1d.row, np.array([0]))
 
 
 def test_1d_add_dense():
@@ -237,7 +238,7 @@ def test_1d_add_dense():
     den_b = np.array([0, 1, 2, 3])
     exp = den_a + den_b
     res = coo_array(den_a) + den_b
-    assert type(res) == type(exp)
+    assert isinstance(res, np.ndarray)
     assert np.array_equal(res, exp)
 
 
@@ -256,6 +257,7 @@ def test_1d_mul_vector():
     den_b = np.array([0, 1, 2, 3])
     exp = den_a @ den_b
     res = coo_array(den_a) @ den_b
+    assert isinstance(res, np.int_)
     assert np.ndim(res) == 0
     assert np.array_equal(res, exp)
 
@@ -265,7 +267,7 @@ def test_1d_mul_multivector():
     other = np.array([[0, 1, 2, 3], [3, 2, 1, 0]]).T
     exp = den @ other
     res = coo_array(den) @ other
-    assert type(res) == type(exp)
+    assert isinstance(res, np.ndarray)
     assert np.array_equal(res, exp)
 
 

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -161,7 +161,7 @@ def test_transpose_with_axis():
 def test_1d_row_and_col():
     res = coo_array([1, -2, -3])
     assert np.array_equal(res.col, np.array([0, 1, 2]))
-    assert np.array_equal(res.row, np.zeros_like(res.row))
+    assert np.array_equal(res.row, np.zeros_like(res.col))
     assert res.row.dtype == res.col.dtype
 
     res.col = [1, 2, 3]
@@ -238,7 +238,7 @@ def test_1d_add_dense():
     den_b = np.array([0, 1, 2, 3])
     exp = den_a + den_b
     res = coo_array(den_a) + den_b
-    assert isinstance(res, np.ndarray)
+    assert type(res) == type(exp)
     assert np.array_equal(res, exp)
 
 
@@ -257,7 +257,6 @@ def test_1d_mul_vector():
     den_b = np.array([0, 1, 2, 3])
     exp = den_a @ den_b
     res = coo_array(den_a) @ den_b
-    assert isinstance(res, np.int_)
     assert np.ndim(res) == 0
     assert np.array_equal(res, exp)
 
@@ -267,7 +266,7 @@ def test_1d_mul_multivector():
     other = np.array([[0, 1, 2, 3], [3, 2, 1, 0]]).T
     exp = den @ other
     res = coo_array(den) @ other
-    assert isinstance(res, np.ndarray)
+    assert type(res) == type(exp)
     assert np.array_equal(res, exp)
 
 


### PR DESCRIPTION
This impacts `toarray` and `add_dense` (treatments for coo_todense), `row` and `col` properties.
It essentially makes a 1d-array like a row array, instead of like a column array. This is how numpy handles 1d in the sense that it left-pads `shape` with 1s for new dimensions in broadcasting. This will simplify matching with dok, csc, csr 1d-arrays.

Also, in english (no affect on code), the 1d coo_array indices can be though of as columns. We build more dimensions by pre-pending the new index array to the `indices` tuple.  In code, handling conversion of `self.shape` to `M, N` (when using sparsetools that intake M, N) with:  `M, N = (self.shape[0] if self.ndim > 1 else 1), self.shape[-1]`

These aren't needed to pass any tests per se, but make matching to the dok, csc, csr needs easier. They need this left-pad rule for using the existing sparsetools for indexing/mul/matmul/etc.