### PR TITLE
Handle 1d with care outside of _coo.py

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -581,8 +581,7 @@ class _spbase:
         # Currently matrix multiplication is only supported
         # for 2D arrays. Hence we unpacked and use only the
         # two last axes' lengths.
-        N = self.shape[-1]
-        M = self.shape[-2] if self.ndim > 1 else 1
+        M, N = self._shape_as_2d
 
         if other.__class__ is np.ndarray:
             # Fast path for the most common case
@@ -600,6 +599,8 @@ class _spbase:
         if issparse(other):
             if self.shape[1] != other.shape[0]:
                 raise ValueError('dimension mismatch')
+            if other.ndim == 1:
+                raise ValueError('Cannot yet multiply a 1d sparse array')
             return self._mul_sparse_matrix(other)
 
         # If it's a list or whatever, treat it like an array

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -370,6 +370,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             if self.shape == other.shape:
                 other = self.__class__(other)
                 return self._binopt(other, '_elmul_')
+            if other.ndim == 1:
+                raise TypeError("broadcast from a 1d array not yet supported")
             # Single element.
             elif other.shape == (1, 1):
                 return self._mul_scalar(other.toarray()[0, 0])

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -935,6 +935,8 @@ def block_diag(mats, format=None, dtype=None):
         nrows, ncols = a.shape
         if issparse(a):
             a = a.tocoo()
+            if a.ndim == 1:
+                a = a.reshape((a._shape_as_2d))
             row.append(a.row + r_idx)
             col.append(a.col + c_idx)
             data.append(a.data)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -932,15 +932,14 @@ def block_diag(mats, format=None, dtype=None):
     for a in mats:
         if isinstance(a, (list, numbers.Number)):
             a = coo_array(np.atleast_2d(a))
-        nrows, ncols = a.shape
         if issparse(a):
             a = a.tocoo()
-            if a.ndim == 1:
-                a = a.reshape((a._shape_as_2d))
+            nrows, ncols = a._shape_as_2d
             row.append(a.row + r_idx)
             col.append(a.col + c_idx)
             data.append(a.data)
         else:
+            nrows, ncols = a.shape
             a_row, a_col = np.divmod(np.arange(nrows*ncols), ncols)
             row.append(a_row + r_idx)
             col.append(a_col + c_idx)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -565,6 +565,12 @@ class TestConstructUtils:
         # one 1d matrix and a scalar
         assert_array_equal(construct.block_diag([[2,3], 4]).toarray(),
                            [[2, 3, 0], [0, 0, 4]])
+        # 1d sparse arrays
+        A = coo_array([1,0,3])
+        B = coo_array([0,4])
+        assert_array_equal(construct.block_diag([A, B]).toarray(),
+                           [[1, 0, 3, 0, 0], [0, 0, 0, 0, 4]])
+
 
     def test_block_diag_1(self):
         """ block_diag with one matrix """


### PR DESCRIPTION
I've made a PR to this PR with hopeful resolutions. The 3 places in `scipy/sparse` class code where 1d might cause trouble are as follows.:
1) In `_spbase._mul_dispatch` we should avoid sending the 1d-array on to `_mul_sparse_matrix`. We could either raise an exception, or convert to dense for now to `self._mul_vector(other.toarray())`. In PR-PR I raised a ValueError.
2) In `_compressed`, the `multiply` function doesn't handle 1d sparse well unless both `self` and `other` are the same shape (where a ValueError says 1d cannot convert to csr). So I put a TypeError about broadcasting not ready for 1d into the PR-PR.
3) In `_construct` the `blockdiag` function doesn't handle a 1d block. We could either raise an exception, or reshape 1d as a 1xN 2d array. In PR-PR it reshapes to a 2d row array.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
